### PR TITLE
fix: Export `DiagnosticVisitor` from execution/mod.rs

### DIFF
--- a/depends/src/execution/mod.rs
+++ b/depends/src/execution/mod.rs
@@ -26,7 +26,7 @@ pub use node::{NodeHash, NodeRef, NodeState};
 pub use resolve::Resolve;
 pub use update_derived::UpdateDerived;
 pub use update_input::UpdateInput;
-pub use visitor::{HashSetVisitor, Visitor};
+pub use visitor::{DiagnosticVisitor, HashSetVisitor, Visitor};
 
 #[cfg(feature = "graphviz")]
 mod graph_create;

--- a/depends/src/execution/test_utils.rs
+++ b/depends/src/execution/test_utils.rs
@@ -2,4 +2,4 @@
 //!
 //! This module contains utilities for testing and debugging resolution
 //! behaviour.
-pub use super::{identifiable::ext_reset_node_id, visitor::DiagnosticVisitor};
+pub use super::identifiable::ext_reset_node_id;

--- a/examples/src/docs/raising_the_stakes.rs
+++ b/examples/src/docs/raising_the_stakes.rs
@@ -48,8 +48,9 @@ impl UpdateDerived<DepRef<'_, SomeNumber>, Cube> for AnotherNumber {
 fn test_resolve_graph() {
 use super::multiple_dependencies::Multiply;
 use super::simple_value::Square;
-use depends::test_utils::{ext_reset_node_id, DiagnosticVisitor};
+use depends::test_utils::{ext_reset_node_id};
 use depends::{
+    DiagnosticVisitor,
     graphviz::GraphvizVisitor, *
 };
 use std::rc::Rc;

--- a/examples/src/docs/raising_the_stakes.rs
+++ b/examples/src/docs/raising_the_stakes.rs
@@ -50,7 +50,6 @@ use super::multiple_dependencies::Multiply;
 use super::simple_value::Square;
 use depends::test_utils::{ext_reset_node_id};
 use depends::{
-    DiagnosticVisitor,
     graphviz::GraphvizVisitor, *
 };
 use std::rc::Rc;


### PR DESCRIPTION
Exporting the `DiagnosticVisitor` as mentioned in #40 - so it can be used with `use depends::{DiagnosticVisitor};`. I hope exporting it was intended.

I tested this by patching the depends package locally with

```toml
[patch.crates-io]
depends = { git="https://github.com/janis-me/depends-rs", branch="fix/export-diagnostics-visitor" }
```
and it works well!

~ Cheers